### PR TITLE
Include polyfill for Node `stream` API to ensure compatibility with Webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/crypto-browserify/cipher-base#readme",
   "dependencies": {
+    "stream": "npm:stream-browserify@^3.0.0",
     "inherits": "^2.0.1",
     "safe-buffer": "^5.0.1"
   },


### PR DESCRIPTION
_This should fix #10_.

This library makes use of the `stream` module. This is a Node API that's no longer polyfilled by Webpack 5.

Anyone who depends upon `cipher-base` won't be able to upgrade their project to Webpack 5. Webpack will fail to build their project, citing that `stream` is missing. This also implies that anyone trying to use `cipher-base` with Create React App 5 won't be able to either, since CRA5 uses Webpack 5.

Here's an example of folks in the Web3 community having trouble with this: https://github.com/solana-labs/wallet-adapter/issues/241

Test plan: `yarn test`.