### PR TITLE
Changed to readable-stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var Buffer = require('safe-buffer').Buffer
-var Transform = require('stream').Transform
+var Transform = require('readable-stream')
 var StringDecoder = require('string_decoder').StringDecoder
 var inherits = require('inherits')
 


### PR DESCRIPTION
Because `stream` does not export `Transform`.

https://github.com/crypto-browserify/cipher-base/issues/17