### PR TITLE
[Fix] return valid values on multi-byte-wide TypedArray input

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,11 @@
     "func-style": "off",
   },
 
+  "globals": {
+    "Uint8Array": false,
+    "Uint16Array": false,
+  },
+
   "overrides": [
     {
       "files": [

--- a/test/index.js
+++ b/test/index.js
@@ -128,3 +128,28 @@ test('encodings', function (t) {
 		st.equals(txt, enc);
 	});
 });
+
+test('handle UInt16Array', function (t) {
+	function Cipher() {
+		CipherBase.call(this, 'finalName');
+		this._cache = [];
+	}
+	inherits(Cipher, CipherBase);
+	Cipher.prototype._update = function (input) {
+		t.ok(Buffer.isBuffer(input));
+		this._cache.push(input);
+	};
+	Cipher.prototype._final = function () {
+		return Buffer.concat(this._cache);
+	};
+
+	if (ArrayBuffer.isView && (Buffer.prototype instanceof Uint8Array || Buffer.TYPED_ARRAY_SUPPORT)) {
+		var cipher = new Cipher();
+		var final = cipher.update(new Uint16Array([1234, 512])).finalName('hex');
+		t.equals(final, 'd2040002');
+	} else {
+		t.skip('ArrayBuffer.isView and/or TypedArray not fully supported');
+	}
+
+	t.end();
+});


### PR DESCRIPTION
Node.js supports any TypedArray or DataView as input, this lib miscalculated on e.g. Uint16Arrays
This patch fixes that

`Uint8Array` is checked with typeof in `index.js`

Support for historic Node.js versions on non-Uint8Array Buffer impls and old https://npmjs.com/buffer versions in environments without proper Uint8Array is kept at best-effort (will work on everything that both it and Node.js worked correctly on but will throw on unsupported values, i.e. wide typed arrays when Buffer is not a subclass of Uint8Array)